### PR TITLE
Correct search tool path handling and ugrep recursion

### DIFF
--- a/src/code_index_mcp/search/base.py
+++ b/src/code_index_mcp/search/base.py
@@ -70,8 +70,13 @@ def parse_search_output(
             
             line_number = int(line_number_str)
 
-            # Make the file path relative to the base_path
-            relative_path = os.path.relpath(file_path_abs, normalized_base_path)
+            # If the path is already relative (doesn't start with /), keep it as is
+            # Otherwise, make it relative to the base_path
+            if os.path.isabs(file_path_abs):
+                relative_path = os.path.relpath(file_path_abs, normalized_base_path)
+            else:
+                # Path is already relative, use it as is
+                relative_path = file_path_abs
             
             # Normalize path separators for consistency
             relative_path = normalize_file_path(relative_path)

--- a/src/code_index_mcp/search/ugrep.py
+++ b/src/code_index_mcp/search/ugrep.py
@@ -46,7 +46,7 @@ class UgrepStrategy(SearchStrategy):
         if not self.is_available():
             return {"error": "ugrep (ug) command not found."}
 
-        cmd = ['ug', '--line-number', '--no-heading']
+        cmd = ['ug', '-r', '--line-number', '--no-heading']
 
         if fuzzy:
             # ugrep has native fuzzy search support
@@ -67,7 +67,7 @@ class UgrepStrategy(SearchStrategy):
             cmd.extend(['-A', str(context_lines), '-B', str(context_lines)])
             
         if file_pattern:
-            cmd.extend(['-g', file_pattern])  # Correct parameter for file patterns
+            cmd.extend(['--include', file_pattern])
 
         # Add '--' to treat pattern as a literal argument, preventing injection
         cmd.append('--')


### PR DESCRIPTION
- Fix relative path handling in parse_search_output to work correctly with all search tools
- Add recursive flag (-r) to ugrep which doesn't recurse by default
- Change ugrep file pattern from -g to --include for proper glob filtering