### PR TITLE
feat: add configurable observer_type for file watcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,17 @@ If automatic index updates aren't working when files change, try:
 - Use manual refresh: Call the `refresh_index` tool after making file changes
 - Check file watcher status: Use `get_file_watcher_status` to verify monitoring is active
 
+### **macOS File Watcher Options**
+
+The default FSEvents observer works well for most projects. If you experience issues, you can switch to an alternative observer via `configure_file_watcher`:
+
+- `"auto"` (default): Platform default (FSEvents on macOS)
+- `"kqueue"`: Kqueue observer (macOS/BSD)
+- `"fsevents"`: Force FSEvents (macOS only)
+- `"polling"`: Cross-platform polling fallback
+
+Note: Kqueue opens one file descriptor per watched file. For large projects using kqueue, you may need to increase the limit: `ulimit -n 10240`
+
 ## Development & Contributing
 
 ### 🔧 **Building from Source**

--- a/src/code_index_mcp/server.py
+++ b/src/code_index_mcp/server.py
@@ -324,10 +324,22 @@ def configure_file_watcher(
     ctx: Context,
     enabled: bool = None,
     debounce_seconds: float = None,
-    additional_exclude_patterns: list = None
+    additional_exclude_patterns: list = None,
+    observer_type: str = None
 ) -> str:
-    """Configure file watcher service settings."""
-    return SystemManagementService(ctx).configure_file_watcher(enabled, debounce_seconds, additional_exclude_patterns)
+    """Configure file watcher service settings.
+
+    Args:
+        enabled: Whether to enable file watcher
+        debounce_seconds: Debounce time in seconds before triggering rebuild
+        additional_exclude_patterns: Additional directory/file patterns to exclude
+        observer_type: Observer backend to use. Options:
+            - "auto" (default): kqueue on macOS for reliability, platform default elsewhere
+            - "kqueue": Force kqueue observer (macOS/BSD)
+            - "fsevents": Force FSEvents observer (macOS only, has known reliability issues)
+            - "polling": Cross-platform polling fallback (slower but most compatible)
+    """
+    return SystemManagementService(ctx).configure_file_watcher(enabled, debounce_seconds, additional_exclude_patterns, observer_type)
 
 # ----- PROMPTS -----
 # Removed: analyze_code, code_search, set_project prompts

--- a/tests/services/test_file_watcher_observer.py
+++ b/tests/services/test_file_watcher_observer.py
@@ -1,0 +1,73 @@
+"""Tests for file watcher observer selection.
+
+Verify that the observer factory correctly selects the appropriate
+observer class based on platform and configuration.
+"""
+
+import platform
+import pytest
+from unittest.mock import patch
+
+from code_index_mcp.services.file_watcher_service import _get_observer_class
+
+
+def test_auto_uses_platform_default():
+    """Verify auto mode uses platform default observer."""
+    # Auto should use the default Observer class (platform default)
+    # On macOS this is FSEventsObserver, on Linux InotifyObserver, etc.
+    ObserverClass = _get_observer_class('auto')
+    assert ObserverClass is not None
+    # Should NOT be kqueue (that's opt-in now)
+    assert 'Kqueue' not in ObserverClass.__name__
+
+
+def test_auto_uses_default_on_linux():
+    """Verify auto mode uses platform default on Linux."""
+    with patch('code_index_mcp.services.file_watcher_service.platform.system', return_value='Linux'):
+        ObserverClass = _get_observer_class('auto')
+        # On Linux, should get the default Observer (InotifyObserver)
+        assert ObserverClass is not None
+
+
+def test_auto_uses_default_on_windows():
+    """Verify auto mode uses platform default on Windows."""
+    with patch('code_index_mcp.services.file_watcher_service.platform.system', return_value='Windows'):
+        ObserverClass = _get_observer_class('auto')
+        # On Windows, should get the default Observer (WindowsApiObserver or ReadDirectoryChangesW)
+        assert ObserverClass is not None
+
+
+def test_explicit_kqueue():
+    """Verify explicit kqueue selection works."""
+    ObserverClass = _get_observer_class('kqueue')
+    assert 'Kqueue' in ObserverClass.__name__
+
+
+def test_explicit_polling():
+    """Verify explicit polling selection works."""
+    ObserverClass = _get_observer_class('polling')
+    assert 'Polling' in ObserverClass.__name__
+
+
+def test_fsevents_only_on_macos():
+    """Verify fsevents raises error on non-macOS."""
+    with patch('code_index_mcp.services.file_watcher_service.platform.system', return_value='Linux'):
+        with pytest.raises(ValueError, match="only available on macOS"):
+            _get_observer_class('fsevents')
+
+
+def test_fsevents_works_on_macos():
+    """Verify fsevents can be selected on macOS."""
+    # Only run this test on actual macOS since fsevents module won't exist elsewhere
+    if platform.system() == 'Darwin':
+        ObserverClass = _get_observer_class('fsevents')
+        assert 'FSEvents' in ObserverClass.__name__
+
+
+def test_invalid_observer_type_falls_back_to_auto():
+    """Verify invalid observer_type falls back to auto behavior."""
+    # Invalid types should fall through to the else (auto) branch
+    ObserverClass = _get_observer_class('invalid_type')
+    # Should get the platform default (auto behavior), not kqueue
+    assert ObserverClass is not None
+    assert 'Kqueue' not in ObserverClass.__name__


### PR DESCRIPTION
## Summary

Adds configurable `observer_type` parameter to `configure_file_watcher` tool, allowing users to choose their preferred file system observer.

## Changes

- Add `_get_observer_class()` factory function for observer selection
- Add `observer_type` parameter to `configure_file_watcher` tool
- Options: `"auto"` (default), `"kqueue"`, `"fsevents"`, `"polling"`
- Update `get_status()` to report observer type and class name
- Update README with macOS file watcher options

## Configuration

```python
configure_file_watcher(observer_type="auto")      # Platform default (recommended)
configure_file_watcher(observer_type="kqueue")    # Kqueue (macOS/BSD)
configure_file_watcher(observer_type="fsevents")  # FSEvents (macOS only)
configure_file_watcher(observer_type="polling")   # Cross-platform polling fallback
```

## Note on Kqueue

Kqueue opens one file descriptor per watched file. For large projects using kqueue, you may need to increase the limit: `ulimit -n 10240`

## Testing

- Added 8 tests covering observer selection
- All tests pass

## References

- Closes #70