### PR TITLE
Fix deep index stalls by skipping binary files and speeding up call resolution

### DIFF
--- a/tests/indexing/test_binary_file_skip.py
+++ b/tests/indexing/test_binary_file_skip.py
@@ -1,0 +1,15 @@
+"""Tests for skipping binary files during deep indexing."""
+
+from code_index_mcp.indexing.sqlite_index_manager import SQLiteIndexManager
+
+
+def test_sqlite_index_manager_skips_files_containing_nul_bytes(tmp_path):
+    (tmp_path / "main.py").write_text("def foo():\n    return 1\n", encoding="utf-8")
+    (tmp_path / "binary.index").write_bytes(b"\x00binary-content")
+
+    manager = SQLiteIndexManager()
+    assert manager.set_project_path(str(tmp_path))
+    assert manager.build_index()
+
+    stats = manager.get_index_stats()
+    assert stats["indexed_files"] == 1


### PR DESCRIPTION
## Problem

- Deep indexing could hang or take ~10–15 minutes on Unity projects because binary `.index` files were parsed as text and the call-resolution step performed O(N×M) suffix scans across all symbols.
- In the Unity `Library` folder, large binary search index files caused excessive time and potential stalls; additionally, the global call resolution scaled poorly with thousands of symbols.

## Fix

- In `src/code_index_mcp/indexing/json_index_builder.py`, detect NUL bytes from a small binary probe and skip those files entirely.
- In `src/code_index_mcp/indexing/sqlite_index_builder.py` and `src/code_index_mcp/indexing/json_index_builder.py`, precompute unique short-name and suffix maps so each pending call resolves in O(1), preserving the “only unique match is accepted” behavior.
- Added regression test: `tests/indexing/test_binary_file_skip.py`.

## Notes / Risks

- Behavior of `called_by` resolution is unchanged for unique matches; ambiguous matches are still skipped.
- Binary skip is based on NUL detection and applies uniformly across extensions, preventing accidental text parsing of binary artifacts.
