### PR TITLE
fix(search): use correct ugrep exclude flags instead of invalid --ignore

### DIFF
--- a/src/code_index_mcp/search/ugrep.py
+++ b/src/code_index_mcp/search/ugrep.py
@@ -75,7 +75,7 @@ class UgrepStrategy(SearchStrategy):
             normalized = directory.strip()
             if not normalized or normalized in processed_patterns:
                 continue
-            cmd.extend(['--ignore', f'**/{normalized}/**'])
+            cmd.extend(['--exclude-dir', normalized])
             processed_patterns.add(normalized)
 
         for pattern in exclude_file_patterns:
@@ -83,12 +83,12 @@ class UgrepStrategy(SearchStrategy):
             if not normalized or normalized in processed_patterns:
                 continue
             if normalized.startswith('!'):
-                ignore_pattern = normalized[1:]
+                exclude_pattern = normalized[1:]
             elif any(ch in normalized for ch in '*?[') or '/' in normalized:
-                ignore_pattern = normalized
+                exclude_pattern = normalized
             else:
-                ignore_pattern = f'**/{normalized}'
-            cmd.extend(['--ignore', ignore_pattern])
+                exclude_pattern = f'**/{normalized}'
+            cmd.extend(['--exclude', exclude_pattern])
             processed_patterns.add(normalized)
 
         # Add '--' to treat pattern as a literal argument, preventing injection


### PR DESCRIPTION
## Summary

Fixes #79 — `search_code_advanced` returns 0 results when ugrep is the selected search tool.

## Bug

The `--ignore` flag used in `ugrep.py` for excluding directories and file patterns is **not a valid ugrep option**. This causes ugrep to exit with code 2 (usage error), but the error is silently swallowed through the filter/paginate pipeline, so `search_code_advanced` always returns 0 results instead of surfacing the error.

## Impact

Any user with ugrep as their primary search tool gets **zero results for every search**, with no visible error message.

## Fix

Replace the invalid `--ignore` flag with the correct ugrep flags:

- **Directories**: `--exclude-dir <dir>` instead of `--ignore **/<dir>/**`
- **File patterns**: `--exclude <pattern>` instead of `--ignore <pattern>`

These flags are documented in ugrep's man page and match the behavior of grep/ripgrep equivalents.

## Changes

- `src/code_index_mcp/search/ugrep.py`: replaced all `--ignore` usages with `--exclude-dir` (for directories) and `--exclude` (for file patterns). Also renamed the `ignore_pattern` variable to `exclude_pattern` for clarity.

## Test plan

- [x] Tested on macOS with ugrep installed via Homebrew
- [x] Verified `ug --exclude-dir node_modules --exclude '*.min.js' -r --line-number --no-heading --fixed-strings -- "pattern" .` returns correct results
- [x] Verified the previous command with `--ignore` exits with code 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)