### PR TITLE
Guard kqueue observer on unsupported platforms

### DIFF
--- a/src/code_index_mcp/services/file_watcher_service.py
+++ b/src/code_index_mcp/services/file_watcher_service.py
@@ -10,6 +10,7 @@ It uses the watchdog library for cross-platform file system event monitoring.
 import logging
 import os
 import platform
+import select
 import traceback
 from threading import Timer
 from typing import Optional, Callable, List, Type
@@ -48,6 +49,8 @@ def _get_observer_class(observer_type: str = "auto") -> Type:
     system = platform.system()
 
     if observer_type == "kqueue":
+        if not hasattr(select, "KQ_FILTER_VNODE"):
+            raise ImportError("kqueue observer is not available on this platform")
         from watchdog.observers.kqueue import KqueueObserver
         return KqueueObserver
     elif observer_type == "fsevents":

--- a/tests/services/test_file_watcher_observer.py
+++ b/tests/services/test_file_watcher_observer.py
@@ -5,6 +5,7 @@ observer class based on platform and configuration.
 """
 
 import platform
+import select
 import pytest
 from unittest.mock import patch
 
@@ -41,6 +42,8 @@ def test_explicit_kqueue():
     """Verify explicit kqueue selection works."""
     if platform.system() == 'Windows':
         pytest.skip("kqueue observer import fails on Windows")
+    if not hasattr(select, "KQ_FILTER_VNODE"):
+        pytest.skip("kqueue observer not supported on this platform")
     ObserverClass = _get_observer_class('kqueue')
     assert 'Kqueue' in ObserverClass.__name__
 


### PR DESCRIPTION
## What changed
- Guard kqueue observer selection when the platform lacks kqueue support.
- Skip the explicit kqueue test on platforms without kqueue support.

## Why
- Avoids AttributeError when watchdog imports kqueue on non-kqueue platforms (e.g., Linux).
- Keeps explicit kqueue coverage on supported platforms while making the test suite portable.

## Testing
- ✅ pytest -q (pass)
