### PR TITLE
fix: resolve hash mismatch and --indexer-path ignored in shallow index

### DIFF
--- a/src/code_index_mcp/indexing/shallow_index_manager.py
+++ b/src/code_index_mcp/indexing/shallow_index_manager.py
@@ -19,6 +19,7 @@ import re
 
 from .json_index_builder import JSONIndexBuilder
 from ..constants import SETTINGS_DIR, INDEX_FILE_SHALLOW
+from ..project_settings import ProjectSettings
 
 logger = logging.getLogger(__name__)
 
@@ -58,8 +59,13 @@ class ShallowIndexManager:
                 self.project_path = project_path
                 self.index_builder = JSONIndexBuilder(project_path, additional_excludes)
 
-                project_hash = hashlib.md5(project_path.encode()).hexdigest()[:12]
-                self.temp_dir = os.path.join(tempfile.gettempdir(), SETTINGS_DIR, project_hash)
+                project_hash = hashlib.md5(project_path.encode()).hexdigest()
+                index_root = (
+                    ProjectSettings.custom_index_root
+                    if (hasattr(ProjectSettings, "custom_index_root") and ProjectSettings.custom_index_root)
+                    else os.path.join(tempfile.gettempdir(), SETTINGS_DIR)
+                )
+                self.temp_dir = os.path.join(index_root, project_hash)
                 os.makedirs(self.temp_dir, exist_ok=True)
                 self.index_path = os.path.join(self.temp_dir, INDEX_FILE_SHALLOW)
                 if additional_excludes:

--- a/src/code_index_mcp/indexing/sqlite_index_manager.py
+++ b/src/code_index_mcp/indexing/sqlite_index_manager.py
@@ -279,7 +279,7 @@ class SQLiteIndexManager:
 def _hash_project_path(project_path: str) -> str:
     import hashlib
 
-    return hashlib.md5(project_path.encode()).hexdigest()[:12]
+    return hashlib.md5(project_path.encode()).hexdigest()
 
 
 def _compile_glob_regex(pattern: str):


### PR DESCRIPTION
Two bugs caused the shallow index to be rebuilt on every server startup:

1. Hash length mismatch: shallow_index_manager.py and sqlite_index_manager.py used a 12-char truncated MD5 hash (hexdigest()[:12]) for the storage directory name, while project_settings.py used the full 32-char MD5 hash. This meant the index was written to e.g. /tmp/code_indexer/32697df368a6/ but looked for at /tmp/code_indexer/32697df368a617d19aac2f121d60624f/, so load_index() always failed and the index was always rebuilt from scratch.

   Fix: remove [:12] truncation from both files so all components use the same full 32-char MD5 hash.

2. --indexer-path flag ignored by shallow index: shallow_index_manager.py hardcoded tempfile.gettempdir() and ignored ProjectSettings.custom_index_root, so the --indexer-path CLI argument had no effect on the shallow index storage location (only the deep SQLite index respected it).

   Fix: check ProjectSettings.custom_index_root first, falling back to tempfile.gettempdir() when not set.

Together these fixes ensure the shallow index is written to and loaded from the correct persistent location, eliminating unnecessary rebuilds on startup.