### PR TITLE
feat: support custom file extensions configuration

### DIFF
--- a/docs/superpowers/plans/2026-04-06-pr93-code-review-fixes.md
+++ b/docs/superpowers/plans/2026-04-06-pr93-code-review-fixes.md
@@ -1,0 +1,62 @@
+# PR #93 Code Review Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix 5 code review issues found in PR #93 to improve code quality and correctness of the custom-extensions feature.
+
+**Architecture:** Extract a shared `normalize_extension()` utility to eliminate 3x duplicated normalization logic. Move duplicated service methods (`_get_extra_extensions`, `_get_exclude_patterns`) to `BaseService`. Fix parameter passing to avoid fragile instance variable stashing. Thread extra_extensions through to file watcher's FileFilter.
+
+**Tech Stack:** Python 3.12+, pytest
+
+---
+
+### Task 1: Extract `normalize_extension` utility
+
+**Files:**
+- Create: `src/code_index_mcp/utils/extensions.py`
+- Modify: `src/code_index_mcp/utils/__init__.py`
+- Modify: `src/code_index_mcp/project_settings.py` (update_extra_extensions, get_extra_extensions)
+- Modify: `src/code_index_mcp/utils/file_filter.py` (FileFilter.__init__)
+- Modify: `src/code_index_mcp/server.py` (CLI parsing)
+
+- [ ] Create `normalize_extension(ext: str) -> str` in `utils/extensions.py`
+- [ ] Export from `utils/__init__.py`
+- [ ] Replace inline normalization in `project_settings.py` `update_extra_extensions` and `get_extra_extensions`
+- [ ] Replace inline normalization in `file_filter.py` `FileFilter.__init__` - just call `normalize_extension` on each ext
+- [ ] In `server.py` CLI parsing (lines 524-527), normalize each extension using `normalize_extension`
+
+### Task 2: Remove fragile `_extra_extensions` instance variable
+
+**Files:**
+- Modify: `src/code_index_mcp/services/project_management_service.py`
+
+- [ ] Change `_execute_initialization_workflow(self, path)` signature to accept `extra_extensions: list[str] | None = None`
+- [ ] Remove `self._extra_extensions = extra_extensions` from `initialize_project()`
+- [ ] Pass `extra_extensions` as argument to `_execute_initialization_workflow(path, extra_extensions)`
+- [ ] Replace `getattr(self, '_extra_extensions', None)` with the parameter
+
+### Task 3: Move duplicated `_get_extra_extensions` and `_get_exclude_patterns` to BaseService
+
+**Files:**
+- Modify: `src/code_index_mcp/services/base_service.py`
+- Modify: `src/code_index_mcp/services/project_management_service.py`
+- Modify: `src/code_index_mcp/services/index_management_service.py`
+
+- [ ] Add `_get_extra_extensions` and `_get_exclude_patterns` to `BaseService`
+- [ ] Remove both methods from `ProjectManagementService`
+- [ ] Remove both methods from `IndexManagementService`
+
+### Task 4: Pass extra_extensions to file watcher's FileFilter
+
+**Files:**
+- Modify: `src/code_index_mcp/services/file_watcher_service.py`
+
+- [ ] Add `extra_extensions` parameter to `DebounceEventHandler.__init__`
+- [ ] Pass `extra_extensions` to `FileFilter(additional_excludes, extra_extensions=extra_extensions)`
+- [ ] Update `_create_event_handler` to read extra_extensions from settings and pass through
+- [ ] Update `restart_observer` similarly
+
+### Task 5: Run all tests, commit
+
+- [ ] Run full test suite
+- [ ] Commit all changes

--- a/src/code_index_mcp/indexing/json_index_builder.py
+++ b/src/code_index_mcp/indexing/json_index_builder.py
@@ -51,7 +51,7 @@ class JSONIndexBuilder:
     4. Assembling the final JSON index
     """
 
-    def __init__(self, project_path: str, additional_excludes: Optional[List[str]] = None):
+    def __init__(self, project_path: str, additional_excludes: Optional[List[str]] = None, extra_extensions: Optional[List[str]] = None):
         from ..utils import FileFilter
 
         # Input validation
@@ -68,7 +68,7 @@ class JSONIndexBuilder:
         self.project_path = project_path
         self.in_memory_index: Optional[Dict[str, Any]] = None
         self.strategy_factory = StrategyFactory()
-        self.file_filter = FileFilter(additional_excludes)
+        self.file_filter = FileFilter(additional_excludes, extra_extensions=extra_extensions)
 
         logger.info(f"Initialized JSON index builder for {project_path}")
         strategy_info = self.strategy_factory.get_strategy_info()

--- a/src/code_index_mcp/indexing/shallow_index_manager.py
+++ b/src/code_index_mcp/indexing/shallow_index_manager.py
@@ -34,13 +34,15 @@ class ShallowIndexManager:
         self._file_list: Optional[List[str]] = None
         self._lock = threading.RLock()
 
-    def set_project_path(self, project_path: str, additional_excludes: Optional[List[str]] = None) -> bool:
+    def set_project_path(self, project_path: str, additional_excludes: Optional[List[str]] = None, extra_extensions: Optional[List[str]] = None) -> bool:
         """Configure project path for shallow indexing.
 
         Args:
             project_path: Path to the project directory to index
             additional_excludes: Optional list of additional directory/file
                 patterns to exclude from indexing (e.g., ['vendor', 'custom_deps'])
+            extra_extensions: Optional list of additional file extensions to
+                include in indexing (e.g., ['.rsc', '.conf'])
 
         Returns:
             True if configuration succeeded, False otherwise
@@ -56,7 +58,7 @@ class ShallowIndexManager:
                     return False
 
                 self.project_path = project_path
-                self.index_builder = JSONIndexBuilder(project_path, additional_excludes)
+                self.index_builder = JSONIndexBuilder(project_path, additional_excludes, extra_extensions=extra_extensions)
 
                 project_hash = hashlib.md5(project_path.encode()).hexdigest()[:12]
                 self.temp_dir = os.path.join(tempfile.gettempdir(), SETTINGS_DIR, project_hash)

--- a/src/code_index_mcp/indexing/sqlite_index_builder.py
+++ b/src/code_index_mcp/indexing/sqlite_index_builder.py
@@ -34,8 +34,9 @@ class SQLiteIndexBuilder(JSONIndexBuilder):
         project_path: str,
         store: SQLiteIndexStore,
         additional_excludes: Optional[List[str]] = None,
+        extra_extensions: Optional[List[str]] = None,
     ):
-        super().__init__(project_path, additional_excludes)
+        super().__init__(project_path, additional_excludes, extra_extensions=extra_extensions)
         self.store = store
 
     def build_index(

--- a/src/code_index_mcp/indexing/sqlite_index_manager.py
+++ b/src/code_index_mcp/indexing/sqlite_index_manager.py
@@ -35,13 +35,15 @@ class SQLiteIndexManager:
         self._lock = threading.RLock()
         logger.info("Initialized SQLite Index Manager")
 
-    def set_project_path(self, project_path: str, additional_excludes: Optional[List[str]] = None) -> bool:
+    def set_project_path(self, project_path: str, additional_excludes: Optional[List[str]] = None, extra_extensions: Optional[List[str]] = None) -> bool:
         """Configure project path and underlying storage location.
 
         Args:
             project_path: Path to the project directory to index
             additional_excludes: Optional list of additional directory/file
                 patterns to exclude from indexing (e.g., ['vendor', 'custom_deps'])
+            extra_extensions: Optional list of additional file extensions to
+                include in indexing (e.g., ['.rsc', '.conf'])
 
         Returns:
             True if configuration succeeded, False otherwise
@@ -72,11 +74,13 @@ class SQLiteIndexManager:
 
             self.shallow_index_path = os.path.join(self.temp_dir, INDEX_FILE_SHALLOW)
             self.store = SQLiteIndexStore(self.index_path)
-            self.index_builder = SQLiteIndexBuilder(project_path, self.store, additional_excludes)
+            self.index_builder = SQLiteIndexBuilder(project_path, self.store, additional_excludes, extra_extensions=extra_extensions)
             self._is_loaded = False
             logger.info("SQLite index storage: %s", self.index_path)
             if additional_excludes:
                 logger.info("Additional excludes: %s", additional_excludes)
+            if extra_extensions:
+                logger.info("Extra extensions: %s", extra_extensions)
             return True
 
     def build_index(self, force_rebuild: bool = False) -> bool:

--- a/src/code_index_mcp/project_settings.py
+++ b/src/code_index_mcp/project_settings.py
@@ -563,13 +563,12 @@ class ProjectSettings:
         Args:
             extensions: List of file extensions to add
         """
-        normalized = []
-        for ext in extensions:
-            ext = ext.strip().lower()
-            if ext and not ext.startswith('.'):
-                ext = '.' + ext
-            if ext:
-                normalized.append(ext)
+        from .utils.extensions import normalize_extension
+
+        normalized = [
+            norm for ext in extensions
+            if (norm := normalize_extension(ext))
+        ]
         config = self.load_config()
         config["extra_extensions"] = normalized
         self.save_config(config)
@@ -593,14 +592,14 @@ class ProjectSettings:
             extensions.extend(config_exts)
 
         # From environment variable
+        from .utils.extensions import normalize_extension
+
         env_val = os.environ.get("EXTRA_EXTENSIONS", "")
         if env_val:
-            for ext in env_val.split(","):
-                ext = ext.strip().lower()
-                if ext and not ext.startswith('.'):
-                    ext = '.' + ext
-                if ext:
-                    extensions.append(ext)
+            for raw in env_val.split(","):
+                norm = normalize_extension(raw)
+                if norm:
+                    extensions.append(norm)
 
         # Deduplicate while preserving order
         seen: set[str] = set()

--- a/src/code_index_mcp/project_settings.py
+++ b/src/code_index_mcp/project_settings.py
@@ -553,3 +553,60 @@ class ProjectSettings:
         config = self.load_config()
         config["additional_exclude_patterns"] = patterns
         self.save_config(config)
+
+    def update_extra_extensions(self, extensions: list) -> None:
+        """Update custom file extensions for indexing.
+
+        Each extension should start with a dot (e.g., '.rsc', '.conf').
+        Extensions are normalized to lowercase with a leading dot.
+
+        Args:
+            extensions: List of file extensions to add
+        """
+        normalized = []
+        for ext in extensions:
+            ext = ext.strip().lower()
+            if ext and not ext.startswith('.'):
+                ext = '.' + ext
+            if ext:
+                normalized.append(ext)
+        config = self.load_config()
+        config["extra_extensions"] = normalized
+        self.save_config(config)
+
+    def get_extra_extensions(self) -> list:
+        """Get custom file extensions from config and environment variable.
+
+        Extensions from the EXTRA_EXTENSIONS environment variable
+        (comma-separated, e.g., '.rsc,.conf,.rules') are merged with
+        any extensions stored in the project config.
+
+        Returns:
+            List of extra file extensions (normalized, deduplicated)
+        """
+        extensions: list[str] = []
+
+        # From project config
+        config = self.load_config()
+        config_exts = config.get("extra_extensions", [])
+        if isinstance(config_exts, list):
+            extensions.extend(config_exts)
+
+        # From environment variable
+        env_val = os.environ.get("EXTRA_EXTENSIONS", "")
+        if env_val:
+            for ext in env_val.split(","):
+                ext = ext.strip().lower()
+                if ext and not ext.startswith('.'):
+                    ext = '.' + ext
+                if ext:
+                    extensions.append(ext)
+
+        # Deduplicate while preserving order
+        seen: set[str] = set()
+        result: list[str] = []
+        for ext in extensions:
+            if ext not in seen:
+                seen.add(ext)
+                result.append(ext)
+        return result

--- a/src/code_index_mcp/server.py
+++ b/src/code_index_mcp/server.py
@@ -522,8 +522,11 @@ def main(argv: list[str] | None = None):
 
     # Parse extra extensions from CLI flag
     if args.extra_extensions:
+        from .utils.extensions import normalize_extension
+
         _CLI_CONFIG.extra_extensions = [
-            ext.strip() for ext in args.extra_extensions.split(",") if ext.strip()
+            norm for raw in args.extra_extensions.split(",")
+            if (norm := normalize_extension(raw))
         ]
 
     # Configure custom index root if provided

--- a/src/code_index_mcp/server.py
+++ b/src/code_index_mcp/server.py
@@ -200,6 +200,7 @@ class _CLIConfig:
     """Holds CLI configuration for bootstrap operations."""
 
     project_path: str | None = None
+    extra_extensions: list[str] | None = None
 
 
 class _BootstrapRequestContext:
@@ -236,7 +237,8 @@ async def indexer_lifespan(_server: FastMCP) -> AsyncIterator[CodeIndexerContext
             )
             try:
                 message = ProjectManagementService(bootstrap_ctx).initialize_project(
-                    _CLI_CONFIG.project_path
+                    _CLI_CONFIG.project_path,
+                    extra_extensions=_CLI_CONFIG.extra_extensions,
                 )
                 logger.info("Project initialized from CLI flag: %s", message)
             except Exception as exc:  # pylint: disable=broad-except
@@ -272,9 +274,16 @@ def get_file_content(file_path: str) -> str:
 
 @mcp.tool()
 @handle_mcp_tool_errors(return_type="str")
-def set_project_path(path: str, ctx: Context) -> str:
-    """Set the base project path for indexing."""
-    return ProjectManagementService(ctx).initialize_project(path)
+def set_project_path(path: str, ctx: Context, extra_extensions: list[str] | None = None) -> str:
+    """Set the base project path for indexing.
+
+    Args:
+        path: Project directory path to index
+        extra_extensions: Optional list of additional file extensions to index
+            (e.g., [".rsc", ".conf", ".rules"]). These are added alongside the
+            built-in supported extensions, using the fallback parsing strategy.
+    """
+    return ProjectManagementService(ctx).initialize_project(path, extra_extensions=extra_extensions)
 
 
 @mcp.tool()
@@ -484,6 +493,12 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Custom path for storing indices (overrides default /tmp/code_indexer location).",
     )
     parser.add_argument(
+        "--extra-extensions",
+        dest="extra_extensions",
+        default=None,
+        help="Comma-separated list of additional file extensions to index (e.g., '.rsc,.conf,.rules').",
+    )
+    parser.add_argument(
         "--tool-prefix",
         dest="tool_prefix",
         default=None,
@@ -504,6 +519,12 @@ def main(argv: list[str] | None = None):
 
     # Store CLI configuration for lifespan bootstrap.
     _CLI_CONFIG.project_path = args.project_path
+
+    # Parse extra extensions from CLI flag
+    if args.extra_extensions:
+        _CLI_CONFIG.extra_extensions = [
+            ext.strip() for ext in args.extra_extensions.split(",") if ext.strip()
+        ]
 
     # Configure custom index root if provided
     if args.indexer_path:

--- a/src/code_index_mcp/server.py
+++ b/src/code_index_mcp/server.py
@@ -517,11 +517,17 @@ def main(argv: list[str] | None = None):
     """Main function to run the MCP server."""
     args = _parse_args(argv)
 
+    # Reset CLI config to prevent stale values leaking between repeated calls.
+    _CLI_CONFIG.project_path = None
+    _CLI_CONFIG.extra_extensions = None
+
     # Store CLI configuration for lifespan bootstrap.
     _CLI_CONFIG.project_path = args.project_path
 
-    # Parse extra extensions from CLI flag
-    if args.extra_extensions:
+    # Parse extra extensions from CLI flag.
+    # Use ``is not None`` to distinguish "not provided" (None) from
+    # "explicitly empty" (""), since both are falsy in Python.
+    if args.extra_extensions is not None:
         from .utils.extensions import normalize_extension
 
         _CLI_CONFIG.extra_extensions = [

--- a/src/code_index_mcp/services/base_service.py
+++ b/src/code_index_mcp/services/base_service.py
@@ -6,7 +6,7 @@ ensuring consistent behavior and shared functionality across the service layer.
 """
 
 from abc import ABC
-from typing import Optional
+from typing import List, Optional
 from mcp.server.fastmcp import Context
 
 from ..utils import ContextHelper, ValidationHelper
@@ -116,6 +116,38 @@ class BaseService(ABC):
             The number of indexed files
         """
         return self.helper.file_count
+
+    def _get_exclude_patterns(self) -> List[str]:
+        """Read exclude patterns from project settings for indexing.
+
+        Returns:
+            List of directory/file patterns to exclude from indexing
+        """
+        patterns: List[str] = []
+        if not self.settings:
+            return patterns
+        try:
+            config = self.settings.get_file_watcher_config()
+            for key in ('exclude_patterns', 'additional_exclude_patterns'):
+                for pattern in config.get(key) or []:
+                    if isinstance(pattern, str) and pattern.strip():
+                        patterns.append(pattern.strip())
+        except Exception:  # noqa: BLE001 - fallback if config fails
+            pass
+        return patterns
+
+    def _get_extra_extensions(self) -> List[str]:
+        """Read extra file extensions from project settings and environment.
+
+        Returns:
+            List of additional file extensions to include in indexing
+        """
+        if not self.settings:
+            return []
+        try:
+            return self.settings.get_extra_extensions()
+        except Exception:  # noqa: BLE001 - fallback if config fails
+            return []
 
     @property
     def index_provider(self):

--- a/src/code_index_mcp/services/file_watcher_service.py
+++ b/src/code_index_mcp/services/file_watcher_service.py
@@ -338,11 +338,13 @@ class FileWatcherService(BaseService):
 
     def _create_event_handler(self, debounce_seconds: float) -> "DebounceEventHandler":
         """Create a fresh debounce handler for the current watcher configuration."""
+        extra_exts = self._get_extra_extensions()
         return DebounceEventHandler(
             debounce_seconds=debounce_seconds,
             rebuild_callback=self.rebuild_callback,
             base_path=Path(self.base_path),
             logger=self.logger,
+            extra_extensions=extra_exts or None,
         )
 
     def get_status(self) -> dict:
@@ -385,7 +387,9 @@ class DebounceEventHandler(FileSystemEventHandler):
     """
 
     def __init__(self, debounce_seconds: float, rebuild_callback: Callable,
-                 base_path: Path, logger: logging.Logger, additional_excludes: Optional[List[str]] = None):
+                 base_path: Path, logger: logging.Logger,
+                 additional_excludes: Optional[List[str]] = None,
+                 extra_extensions: Optional[List[str]] = None):
         """
         Initialize the debounce event handler.
 
@@ -395,9 +399,10 @@ class DebounceEventHandler(FileSystemEventHandler):
             base_path: Base project path for filtering
             logger: Logger instance for debug messages
             additional_excludes: Additional patterns to exclude
+            extra_extensions: Additional file extensions to monitor
         """
         from ..utils import FileFilter
-        
+
         super().__init__()
         self.debounce_seconds = debounce_seconds
         self.rebuild_callback = rebuild_callback
@@ -410,8 +415,8 @@ class DebounceEventHandler(FileSystemEventHandler):
         self._stopped = False
         self._inflight_callbacks = 0
 
-        # Use centralized file filtering
-        self.file_filter = FileFilter(additional_excludes)
+        # Use centralized file filtering with extra extensions
+        self.file_filter = FileFilter(additional_excludes, extra_extensions=extra_extensions)
 
     def on_any_event(self, event: FileSystemEvent) -> None:
         """

--- a/src/code_index_mcp/services/index_management_service.py
+++ b/src/code_index_mcp/services/index_management_service.py
@@ -58,11 +58,12 @@ class IndexManagementService(BaseService):
         # Business validation
         self._validate_rebuild_request()
 
-        # Get user-configured exclude patterns
+        # Get user-configured exclude patterns and extra extensions
         excludes = self._get_exclude_patterns()
+        extra_exts = self._get_extra_extensions()
 
         # Shallow rebuild only (fast path)
-        if not self._shallow_manager.set_project_path(self.base_path, excludes):
+        if not self._shallow_manager.set_project_path(self.base_path, excludes, extra_extensions=extra_exts):
             raise RuntimeError("Failed to set project path (shallow) in index manager")
         if not self._shallow_manager.build_index():
             raise RuntimeError("Failed to rebuild shallow index")
@@ -131,6 +132,19 @@ class IndexManagementService(BaseService):
             pass
         return patterns
 
+    def _get_extra_extensions(self) -> List[str]:
+        """Read extra file extensions from project settings and environment.
+
+        Returns:
+            List of additional file extensions to include in indexing
+        """
+        if not self.settings:
+            return []
+        try:
+            return self.settings.get_extra_extensions()
+        except Exception:  # noqa: BLE001 - fallback if config fails
+            return []
+
     def _execute_rebuild_workflow(self) -> IndexRebuildResult:
         """
         Execute the core index rebuild business workflow.
@@ -140,11 +154,12 @@ class IndexManagementService(BaseService):
         """
         start_time = time.time()
 
-        # Get user-configured exclude patterns
+        # Get user-configured exclude patterns and extra extensions
         excludes = self._get_exclude_patterns()
+        extra_exts = self._get_extra_extensions()
 
-        # Set project path in index manager with exclusions
-        if not self._index_manager.set_project_path(self.base_path, excludes):
+        # Set project path in index manager with exclusions and extra extensions
+        if not self._index_manager.set_project_path(self.base_path, excludes, extra_extensions=extra_exts):
             raise RuntimeError("Failed to set project path in index manager")
 
         # Rebuild the index
@@ -190,11 +205,12 @@ class IndexManagementService(BaseService):
         # Ensure project is set up
         self._require_project_setup()
 
-        # Get user-configured exclude patterns
+        # Get user-configured exclude patterns and extra extensions
         excludes = self._get_exclude_patterns()
+        extra_exts = self._get_extra_extensions()
 
-        # Initialize manager with current base path and exclusions
-        if not self._shallow_manager.set_project_path(self.base_path, excludes):
+        # Initialize manager with current base path, exclusions, and extra extensions
+        if not self._shallow_manager.set_project_path(self.base_path, excludes, extra_extensions=extra_exts):
             raise RuntimeError("Failed to set project path in index manager")
 
         # Build shallow index

--- a/src/code_index_mcp/services/index_management_service.py
+++ b/src/code_index_mcp/services/index_management_service.py
@@ -113,38 +113,6 @@ class IndexManagementService(BaseService):
         # Business rule: Project must be set up
         self._require_project_setup()
 
-    def _get_exclude_patterns(self) -> List[str]:
-        """Read exclude patterns from project settings for indexing.
-
-        Returns:
-            List of directory/file patterns to exclude from indexing
-        """
-        patterns: List[str] = []
-        if not self.settings:
-            return patterns
-        try:
-            config = self.settings.get_file_watcher_config()
-            for key in ('exclude_patterns', 'additional_exclude_patterns'):
-                for pattern in config.get(key) or []:
-                    if isinstance(pattern, str) and pattern.strip():
-                        patterns.append(pattern.strip())
-        except Exception:  # noqa: BLE001 - fallback if config fails
-            pass
-        return patterns
-
-    def _get_extra_extensions(self) -> List[str]:
-        """Read extra file extensions from project settings and environment.
-
-        Returns:
-            List of additional file extensions to include in indexing
-        """
-        if not self.settings:
-            return []
-        try:
-            return self.settings.get_extra_extensions()
-        except Exception:  # noqa: BLE001 - fallback if config fails
-            return []
-
     def _execute_rebuild_workflow(self) -> IndexRebuildResult:
         """
         Execute the core index rebuild business workflow.

--- a/src/code_index_mcp/services/project_management_service.py
+++ b/src/code_index_mcp/services/project_management_service.py
@@ -73,7 +73,20 @@ class ProjectManagementService(BaseService):
             pass
         return patterns
 
-    def initialize_project(self, path: str) -> str:
+    def _get_extra_extensions(self) -> List[str]:
+        """Read extra file extensions from project settings and environment.
+
+        Returns:
+            List of additional file extensions to include in indexing
+        """
+        if not self.settings:
+            return []
+        try:
+            return self.settings.get_extra_extensions()
+        except Exception:  # noqa: BLE001 - fallback if config fails
+            return []
+
+    def initialize_project(self, path: str, extra_extensions: list[str] | None = None) -> str:
         """
         Initialize a project with comprehensive business logic.
 
@@ -83,6 +96,7 @@ class ProjectManagementService(BaseService):
 
         Args:
             path: Project directory path to initialize
+            extra_extensions: Optional list of additional file extensions to index
 
         Returns:
             Success message with project information
@@ -92,6 +106,9 @@ class ProjectManagementService(BaseService):
         """
         # Business validation
         self._validate_initialization_request(path)
+
+        # Store extra extensions in project config if provided
+        self._extra_extensions = extra_extensions
 
         # Business workflow: Execute initialization
         result = self._execute_initialization_workflow(path)
@@ -129,6 +146,11 @@ class ProjectManagementService(BaseService):
 
         # Normalize path for consistent processing
         normalized_path = self._config_tool.normalize_project_path(path)
+
+        # Persist extra extensions if provided via tool parameter
+        extra_exts = getattr(self, '_extra_extensions', None)
+        if extra_exts and self.settings:
+            self.settings.update_extra_extensions(extra_exts)
 
         # Business step 2: Cleanup existing project state
         self._cleanup_existing_project()
@@ -182,8 +204,11 @@ class ProjectManagementService(BaseService):
         # Get user-configured exclude patterns
         excludes = self._get_exclude_patterns()
 
-        # Set project path in shallow manager with exclusions
-        if not self._shallow_manager.set_project_path(project_path, excludes):
+        # Get extra extensions from config + env
+        extra_exts = self._get_extra_extensions()
+
+        # Set project path in shallow manager with exclusions and extra extensions
+        if not self._shallow_manager.set_project_path(project_path, excludes, extra_extensions=extra_exts):
             raise RuntimeError(f"Failed to set project path (shallow): {project_path}")
 
         # Update context

--- a/src/code_index_mcp/services/project_management_service.py
+++ b/src/code_index_mcp/services/project_management_service.py
@@ -5,7 +5,7 @@ This service handles the business logic for project initialization, configuratio
 and lifecycle management across the current indexing backends.
 """
 import logging
-from typing import Dict, Any, List
+from typing import Dict, Any
 from dataclasses import dataclass
 from contextlib import contextmanager
 
@@ -54,38 +54,6 @@ class ProjectManagementService(BaseService):
     def _noop_operation(self, *_args, **_kwargs):
         yield
 
-    def _get_exclude_patterns(self) -> List[str]:
-        """Read exclude patterns from project settings for indexing.
-
-        Returns:
-            List of directory/file patterns to exclude from indexing
-        """
-        patterns: List[str] = []
-        if not self.settings:
-            return patterns
-        try:
-            config = self.settings.get_file_watcher_config()
-            for key in ('exclude_patterns', 'additional_exclude_patterns'):
-                for pattern in config.get(key) or []:
-                    if isinstance(pattern, str) and pattern.strip():
-                        patterns.append(pattern.strip())
-        except Exception:  # noqa: BLE001 - fallback if config fails
-            pass
-        return patterns
-
-    def _get_extra_extensions(self) -> List[str]:
-        """Read extra file extensions from project settings and environment.
-
-        Returns:
-            List of additional file extensions to include in indexing
-        """
-        if not self.settings:
-            return []
-        try:
-            return self.settings.get_extra_extensions()
-        except Exception:  # noqa: BLE001 - fallback if config fails
-            return []
-
     def initialize_project(self, path: str, extra_extensions: list[str] | None = None) -> str:
         """
         Initialize a project with comprehensive business logic.
@@ -107,11 +75,8 @@ class ProjectManagementService(BaseService):
         # Business validation
         self._validate_initialization_request(path)
 
-        # Store extra extensions in project config if provided
-        self._extra_extensions = extra_extensions
-
         # Business workflow: Execute initialization
-        result = self._execute_initialization_workflow(path)
+        result = self._execute_initialization_workflow(path, extra_extensions=extra_extensions)
 
         # Business result formatting
         return self._format_initialization_result(result)
@@ -131,12 +96,13 @@ class ProjectManagementService(BaseService):
         if error:
             raise ValueError(error)
 
-    def _execute_initialization_workflow(self, path: str) -> ProjectInitializationResult:
+    def _execute_initialization_workflow(self, path: str, extra_extensions: list[str] | None = None) -> ProjectInitializationResult:
         """
         Execute the core project initialization business workflow.
 
         Args:
             path: Project path to initialize
+            extra_extensions: Optional list of additional file extensions to index
 
         Returns:
             ProjectInitializationResult with initialization data
@@ -148,9 +114,8 @@ class ProjectManagementService(BaseService):
         normalized_path = self._config_tool.normalize_project_path(path)
 
         # Persist extra extensions if provided via tool parameter
-        extra_exts = getattr(self, '_extra_extensions', None)
-        if extra_exts and self.settings:
-            self.settings.update_extra_extensions(extra_exts)
+        if extra_extensions and self.settings:
+            self.settings.update_extra_extensions(extra_extensions)
 
         # Business step 2: Cleanup existing project state
         self._cleanup_existing_project()

--- a/src/code_index_mcp/services/project_management_service.py
+++ b/src/code_index_mcp/services/project_management_service.py
@@ -114,7 +114,7 @@ class ProjectManagementService(BaseService):
         normalized_path = self._config_tool.normalize_project_path(path)
 
         # Persist extra extensions if provided via tool parameter
-        if extra_extensions and self.settings:
+        if extra_extensions is not None and self.settings:
             self.settings.update_extra_extensions(extra_extensions)
 
         # Business step 2: Cleanup existing project state
@@ -269,7 +269,13 @@ class ProjectManagementService(BaseService):
                     logger.debug(f"Starting shallow index rebuild for: {project_path}")
                     # Business logic: File changed, rebuild using SHALLOW index manager
                     try:
-                        if not self._shallow_manager.set_project_path(project_path):
+                        # Re-read exclude patterns and extra extensions from
+                        # settings so custom-extension files survive rebuilds.
+                        excludes = self._get_exclude_patterns()
+                        extra_exts = self._get_extra_extensions()
+                        if not self._shallow_manager.set_project_path(
+                            project_path, excludes, extra_extensions=extra_exts
+                        ):
                             logger.warning("Shallow manager set_project_path failed")
                             return False
                         if self._shallow_manager.build_index():

--- a/src/code_index_mcp/utils/__init__.py
+++ b/src/code_index_mcp/utils/__init__.py
@@ -18,14 +18,16 @@ from .context_helper import ContextHelper
 from .validation import ValidationHelper
 from .response_formatter import ResponseFormatter
 from .file_filter import FileFilter
+from .extensions import normalize_extension
 
 __all__ = [
     'handle_mcp_errors',
     'handle_mcp_resource_errors',
     'handle_mcp_tool_errors',
     'MCPToolError',
-    'ContextHelper', 
+    'ContextHelper',
     'ValidationHelper',
     'ResponseFormatter',
-    'FileFilter'
+    'FileFilter',
+    'normalize_extension',
 ]

--- a/src/code_index_mcp/utils/extensions.py
+++ b/src/code_index_mcp/utils/extensions.py
@@ -1,0 +1,28 @@
+"""
+Extension normalization utilities for the Code Index MCP server.
+
+Provides a single source of truth for normalizing file extensions
+(lowercase, dot-prefixed, stripped) used across the codebase.
+"""
+
+
+def normalize_extension(ext: str) -> str:
+    """Normalize a file extension to lowercase with a leading dot.
+
+    Strips whitespace, lowercases, and ensures a leading dot.
+    Returns an empty string for blank / whitespace-only input.
+
+    Examples:
+        >>> normalize_extension("  .RSC ")
+        '.rsc'
+        >>> normalize_extension("conf")
+        '.conf'
+        >>> normalize_extension("")
+        ''
+    """
+    ext = ext.strip().lower()
+    if not ext:
+        return ""
+    if not ext.startswith("."):
+        ext = "." + ext
+    return ext

--- a/src/code_index_mcp/utils/file_filter.py
+++ b/src/code_index_mcp/utils/file_filter.py
@@ -15,20 +15,30 @@ from ..constants import FILTER_CONFIG
 class FileFilter:
     """Centralized file filtering logic."""
     
-    def __init__(self, additional_excludes: Optional[List[str]] = None):
+    def __init__(self, additional_excludes: Optional[List[str]] = None, extra_extensions: Optional[List[str]] = None):
         """
         Initialize the file filter.
-        
+
         Args:
             additional_excludes: Additional directory patterns to exclude
+            extra_extensions: Additional file extensions to include (e.g., ['.rsc', '.conf'])
         """
         self.exclude_dirs = set(FILTER_CONFIG["exclude_directories"])
         self.exclude_files = set(FILTER_CONFIG["exclude_files"])
         self.supported_extensions = set(FILTER_CONFIG["supported_extensions"])
-        
+
         # Add user-defined exclusions
         if additional_excludes:
             self.exclude_dirs.update(additional_excludes)
+
+        # Add user-defined extra extensions
+        if extra_extensions:
+            for ext in extra_extensions:
+                ext = ext.strip().lower()
+                if ext and not ext.startswith('.'):
+                    ext = '.' + ext
+                if ext:
+                    self.supported_extensions.add(ext)
     
     def should_exclude_directory(self, dir_name: str) -> bool:
         """

--- a/src/code_index_mcp/utils/file_filter.py
+++ b/src/code_index_mcp/utils/file_filter.py
@@ -31,14 +31,14 @@ class FileFilter:
         if additional_excludes:
             self.exclude_dirs.update(additional_excludes)
 
-        # Add user-defined extra extensions
+        # Add user-defined extra extensions (assumed already normalized at entry boundary)
         if extra_extensions:
+            from .extensions import normalize_extension
+
             for ext in extra_extensions:
-                ext = ext.strip().lower()
-                if ext and not ext.startswith('.'):
-                    ext = '.' + ext
-                if ext:
-                    self.supported_extensions.add(ext)
+                norm = normalize_extension(ext)
+                if norm:
+                    self.supported_extensions.add(norm)
     
     def should_exclude_directory(self, dir_name: str) -> bool:
         """

--- a/tests/test_bootstrap_extra_extensions.py
+++ b/tests/test_bootstrap_extra_extensions.py
@@ -1,0 +1,162 @@
+"""End-to-end bootstrap test for custom extensions via CLI.
+
+Proves that the full path works:
+  main() -> _CLI_CONFIG -> indexer_lifespan() -> initialize_project(extra_extensions=...)
+actually delivers extra_extensions through the real startup flow — not just in
+isolated unit-level pieces.
+"""
+
+import asyncio
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch, call
+
+# Ensure src is importable
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from code_index_mcp.project_settings import ProjectSettings
+
+
+def _run_lifespan_via_main(argv: list[str]):
+    """Call ``main(argv)`` but replace ``mcp.run`` with a helper that
+    actually enters the ``indexer_lifespan`` async context manager.
+
+    This exercises the real bootstrap chain:
+      main() -> _CLI_CONFIG -> mcp.run (intercepted) -> indexer_lifespan
+      -> ProjectManagementService.initialize_project(extra_extensions=...)
+
+    Only ``mcp.run`` is mocked (to avoid starting a real stdio server).
+    Everything else — CLI parsing, _CLI_CONFIG, lifespan, settings
+    persistence, service logic — is real.
+
+    Returns the CodeIndexerContext yielded by the lifespan so the caller
+    can inspect settings, file counts, etc.
+    """
+    from code_index_mcp.server import indexer_lifespan, mcp as mcp_server, main
+
+    captured = {}
+
+    def fake_mcp_run(**_kwargs):
+        """Instead of starting a real transport, enter and exit the lifespan."""
+        async def _enter_lifespan():
+            async with indexer_lifespan(mcp_server) as ctx:
+                captured["context"] = ctx
+
+        asyncio.run(_enter_lifespan())
+
+    with patch("code_index_mcp.server.mcp.run", side_effect=fake_mcp_run):
+        main(argv)
+
+    return captured.get("context")
+
+
+class TestBootstrapExtraExtensionsEndToEnd(unittest.TestCase):
+    """End-to-end: main() -> lifespan -> initialize_project -> settings.
+
+    This test proves that calling main() with --extra-extensions flows
+    through the full bootstrap path (CLI parsing -> _CLI_CONFIG ->
+    indexer_lifespan -> ProjectManagementService.initialize_project)
+    and correctly persists or clears extra_extensions in real
+    ProjectSettings — not just in isolated unit-level pieces.
+    """
+
+    def setUp(self):
+        # Isolated temp project directory with sample files
+        self.project_dir = tempfile.mkdtemp(prefix="cimcp_proj_")
+        with open(os.path.join(self.project_dir, "main.py"), "w") as f:
+            f.write("print('hello')\n")
+        with open(os.path.join(self.project_dir, "router.rsc"), "w") as f:
+            f.write("/ip address add\n")
+
+        # Isolated index root so tests don't pollute system /tmp
+        self.index_root = tempfile.mkdtemp(prefix="cimcp_idx_")
+        self._orig_custom_root = getattr(ProjectSettings, "custom_index_root", None)
+        ProjectSettings.custom_index_root = self.index_root
+
+    def tearDown(self):
+        ProjectSettings.custom_index_root = self._orig_custom_root
+        shutil.rmtree(self.project_dir, ignore_errors=True)
+        shutil.rmtree(self.index_root, ignore_errors=True)
+
+    # ------------------------------------------------------------------
+
+    def test_bootstrap_set_then_clear_extra_extensions(self):
+        """Full bootstrap: set extensions via CLI, then clear with empty string.
+
+        Phase 1: ``--extra-extensions .rsc`` -> lifespan calls
+                 initialize_project(path, extra_extensions=[".rsc"]).
+                 ProjectSettings.update_extra_extensions([".rsc"]) persists
+                 the extension to the config file on disk.
+
+        Phase 2: ``--extra-extensions ''`` -> lifespan calls
+                 initialize_project(path, extra_extensions=[]).
+                 ProjectSettings.update_extra_extensions([]) clears the
+                 previously persisted extensions.
+
+        We verify both the in-memory _CLI_CONFIG state AND the on-disk
+        config written by the real ProjectSettings through the full
+        bootstrap chain.
+        """
+        from code_index_mcp.server import _CLI_CONFIG
+
+        # Phase 1 — set extensions via full bootstrap path
+        ctx1 = _run_lifespan_via_main([
+            "--project-path", self.project_dir,
+            "--extra-extensions", ".rsc",
+        ])
+
+        # _CLI_CONFIG should reflect parsed CLI args
+        self.assertEqual(
+            _CLI_CONFIG.extra_extensions, [".rsc"],
+            "_CLI_CONFIG.extra_extensions should be ['.rsc'] after "
+            "main(['--extra-extensions', '.rsc'])",
+        )
+
+        # The lifespan created a real ProjectSettings and called
+        # update_extra_extensions on it. Verify the config file on disk
+        # was written with the extension.
+        config_path = os.path.join(ctx1.settings.settings_path, "config.json")
+        self.assertTrue(
+            os.path.exists(config_path),
+            f"Config file should exist at {config_path} after bootstrap",
+        )
+        with open(config_path, encoding="utf-8") as f:
+            config_phase1 = json.load(f)
+        self.assertIn(
+            ".rsc", config_phase1.get("extra_extensions", []),
+            "Phase 1 failed: .rsc should be persisted in the config file "
+            "after bootstrap with --extra-extensions .rsc",
+        )
+
+        # Phase 2 — clear extensions with explicit empty string
+        ctx2 = _run_lifespan_via_main([
+            "--project-path", self.project_dir,
+            "--extra-extensions", "",
+        ])
+
+        # _CLI_CONFIG should reflect the explicit empty parse
+        self.assertEqual(
+            _CLI_CONFIG.extra_extensions, [],
+            "_CLI_CONFIG.extra_extensions should be [] after "
+            "main(['--extra-extensions', ''])",
+        )
+
+        # The config file written by update_extra_extensions([]) should
+        # now contain an empty list, proving the clearing path works
+        # end-to-end.
+        config_path2 = os.path.join(ctx2.settings.settings_path, "config.json")
+        with open(config_path2, encoding="utf-8") as f:
+            config_phase2 = json.load(f)
+        self.assertEqual(
+            config_phase2.get("extra_extensions", ["NOT_CLEARED"]), [],
+            "Phase 2 failed: extra_extensions should be [] in the config "
+            "file after bootstrap with --extra-extensions ''",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_custom_extensions.py
+++ b/tests/test_custom_extensions.py
@@ -252,3 +252,60 @@ class TestWatcherRebuildPreservesExtensions:
         assert mgr.build_index()
         files_after_good_rebuild = mgr.get_file_list()
         assert any(f.endswith(".rsc") for f in files_after_good_rebuild)
+
+
+# --- CLI bootstrap _CLI_CONFIG behavior ---
+
+
+class TestCLIBootstrapExtraExtensions:
+    """Test that main() correctly updates _CLI_CONFIG for extra_extensions."""
+
+    def test_empty_string_flag_sets_empty_list(self):
+        """--extra-extensions '' should set _CLI_CONFIG.extra_extensions to [] (explicit clear)."""
+        from code_index_mcp.server import _CLI_CONFIG, main
+        from unittest.mock import patch
+
+        with patch("code_index_mcp.server.mcp.run"):
+            main(["--extra-extensions", ""])
+
+        assert _CLI_CONFIG.extra_extensions == []
+
+    def test_omitted_flag_sets_none(self):
+        """Omitting --extra-extensions should set _CLI_CONFIG.extra_extensions to None."""
+        from code_index_mcp.server import _CLI_CONFIG, main
+        from unittest.mock import patch
+
+        with patch("code_index_mcp.server.mcp.run"):
+            main([])
+
+        assert _CLI_CONFIG.extra_extensions is None
+
+    def test_no_stale_leak_between_calls(self):
+        """Calling main() without the flag after a call with it must not leak stale values."""
+        from code_index_mcp.server import _CLI_CONFIG, main
+        from unittest.mock import patch
+
+        with patch("code_index_mcp.server.mcp.run"):
+            main(["--extra-extensions", ".rsc,.conf"])
+
+        assert _CLI_CONFIG.extra_extensions == [".rsc", ".conf"]
+
+        with patch("code_index_mcp.server.mcp.run"):
+            main([])
+
+        assert _CLI_CONFIG.extra_extensions is None
+
+    def test_explicit_clear_after_set(self):
+        """main(['--extra-extensions', '']) after main(['--extra-extensions', '.rsc']) should clear."""
+        from code_index_mcp.server import _CLI_CONFIG, main
+        from unittest.mock import patch
+
+        with patch("code_index_mcp.server.mcp.run"):
+            main(["--extra-extensions", ".rsc"])
+
+        assert _CLI_CONFIG.extra_extensions == [".rsc"]
+
+        with patch("code_index_mcp.server.mcp.run"):
+            main(["--extra-extensions", ""])
+
+        assert _CLI_CONFIG.extra_extensions == []

--- a/tests/test_custom_extensions.py
+++ b/tests/test_custom_extensions.py
@@ -10,9 +10,15 @@ Verify that extra_extensions flows correctly through:
 """
 
 import os
+import shutil
+import sys
+import tempfile
+import unittest
 from pathlib import Path
+from unittest.mock import patch
 
-import pytest
+# Ensure src is importable
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from code_index_mcp.project_settings import ProjectSettings
 from code_index_mcp.utils.file_filter import FileFilter
@@ -23,194 +29,230 @@ from code_index_mcp.indexing.sqlite_index_manager import SQLiteIndexManager
 # --- ProjectSettings ---
 
 
-class TestProjectSettingsExtraExtensions:
+class TestProjectSettingsExtraExtensions(unittest.TestCase):
     """Test extra_extensions persistence in ProjectSettings."""
 
-    def test_update_and_get_extra_extensions(self, tmp_path):
-        settings = ProjectSettings(str(tmp_path))
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
+
+    def test_update_and_get_extra_extensions(self):
+        settings = ProjectSettings(self.tmp_dir)
         settings.update_extra_extensions([".rsc", ".conf", "rules"])
         result = settings.get_extra_extensions()
-        assert ".rsc" in result
-        assert ".conf" in result
-        assert ".rules" in result  # auto-prefixed with dot
+        self.assertIn(".rsc", result)
+        self.assertIn(".conf", result)
+        self.assertIn(".rules", result)  # auto-prefixed with dot
 
-    def test_get_extra_extensions_empty_by_default(self, tmp_path):
-        settings = ProjectSettings(str(tmp_path))
-        assert settings.get_extra_extensions() == []
+    def test_get_extra_extensions_empty_by_default(self):
+        settings = ProjectSettings(self.tmp_dir)
+        self.assertEqual(settings.get_extra_extensions(), [])
 
-    def test_extra_extensions_normalized_lowercase(self, tmp_path):
-        settings = ProjectSettings(str(tmp_path))
+    def test_extra_extensions_normalized_lowercase(self):
+        settings = ProjectSettings(self.tmp_dir)
         settings.update_extra_extensions([".RSC", ".Conf"])
         result = settings.get_extra_extensions()
-        assert ".rsc" in result
-        assert ".conf" in result
+        self.assertIn(".rsc", result)
+        self.assertIn(".conf", result)
 
-    def test_extra_extensions_deduplication(self, tmp_path):
-        settings = ProjectSettings(str(tmp_path))
+    def test_extra_extensions_deduplication(self):
+        settings = ProjectSettings(self.tmp_dir)
         settings.update_extra_extensions([".rsc", ".rsc", ".conf"])
         result = settings.get_extra_extensions()
-        assert result.count(".rsc") == 1
+        self.assertEqual(result.count(".rsc"), 1)
 
-    def test_extra_extensions_from_env_variable(self, tmp_path, monkeypatch):
-        monkeypatch.setenv("EXTRA_EXTENSIONS", ".rsc,.conf,.rules")
-        settings = ProjectSettings(str(tmp_path))
+    @patch.dict(os.environ, {"EXTRA_EXTENSIONS": ".rsc,.conf,.rules"})
+    def test_extra_extensions_from_env_variable(self):
+        settings = ProjectSettings(self.tmp_dir)
         result = settings.get_extra_extensions()
-        assert ".rsc" in result
-        assert ".conf" in result
-        assert ".rules" in result
+        self.assertIn(".rsc", result)
+        self.assertIn(".conf", result)
+        self.assertIn(".rules", result)
 
-    def test_extra_extensions_merged_config_and_env(self, tmp_path, monkeypatch):
-        monkeypatch.setenv("EXTRA_EXTENSIONS", ".env_ext")
-        settings = ProjectSettings(str(tmp_path))
+    @patch.dict(os.environ, {"EXTRA_EXTENSIONS": ".env_ext"})
+    def test_extra_extensions_merged_config_and_env(self):
+        settings = ProjectSettings(self.tmp_dir)
         settings.update_extra_extensions([".config_ext"])
         result = settings.get_extra_extensions()
-        assert ".config_ext" in result
-        assert ".env_ext" in result
+        self.assertIn(".config_ext", result)
+        self.assertIn(".env_ext", result)
 
-    def test_extra_extensions_env_without_dots(self, tmp_path, monkeypatch):
-        monkeypatch.setenv("EXTRA_EXTENSIONS", "rsc,conf")
-        settings = ProjectSettings(str(tmp_path))
+    @patch.dict(os.environ, {"EXTRA_EXTENSIONS": "rsc,conf"})
+    def test_extra_extensions_env_without_dots(self):
+        settings = ProjectSettings(self.tmp_dir)
         result = settings.get_extra_extensions()
-        assert ".rsc" in result
-        assert ".conf" in result
+        self.assertIn(".rsc", result)
+        self.assertIn(".conf", result)
 
 
 # --- FileFilter ---
 
 
-class TestFileFilterExtraExtensions:
+class TestFileFilterExtraExtensions(unittest.TestCase):
     """Test FileFilter includes extra extensions."""
+
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
 
     def test_extra_extension_accepted(self):
         ff = FileFilter(extra_extensions=[".rsc"])
-        assert ".rsc" in ff.supported_extensions
+        self.assertIn(".rsc", ff.supported_extensions)
 
-    def test_extra_extension_file_not_excluded(self, tmp_path):
+    def test_extra_extension_file_not_excluded(self):
         ff = FileFilter(extra_extensions=[".rsc"])
-        test_file = tmp_path / "script.rsc"
+        test_file = Path(self.tmp_dir) / "script.rsc"
         test_file.write_text("# router script")
-        assert not ff.should_exclude_file(test_file)
+        self.assertFalse(ff.should_exclude_file(test_file))
 
-    def test_without_extra_extension_file_excluded(self, tmp_path):
+    def test_without_extra_extension_file_excluded(self):
         ff = FileFilter()
-        test_file = tmp_path / "script.rsc"
+        test_file = Path(self.tmp_dir) / "script.rsc"
         test_file.write_text("# router script")
-        assert ff.should_exclude_file(test_file)
+        self.assertTrue(ff.should_exclude_file(test_file))
 
     def test_extra_extension_normalizes_case(self):
         ff = FileFilter(extra_extensions=[".RSC"])
-        assert ".rsc" in ff.supported_extensions
+        self.assertIn(".rsc", ff.supported_extensions)
 
     def test_extra_extension_adds_dot_prefix(self):
         ff = FileFilter(extra_extensions=["rsc"])
-        assert ".rsc" in ff.supported_extensions
+        self.assertIn(".rsc", ff.supported_extensions)
 
-    def test_should_process_path_with_extra_extension(self, tmp_path):
+    def test_should_process_path_with_extra_extension(self):
         ff = FileFilter(extra_extensions=[".rsc"])
+        tmp_path = Path(self.tmp_dir)
         test_file = tmp_path / "script.rsc"
         test_file.write_text("# content")
-        assert ff.should_process_path(test_file, tmp_path)
+        self.assertTrue(ff.should_process_path(test_file, tmp_path))
 
 
 # --- ShallowIndexManager ---
 
 
-class TestShallowIndexExtraExtensions:
+class TestShallowIndexExtraExtensions(unittest.TestCase):
     """Test that shallow indexing picks up files with custom extensions."""
 
-    def test_shallow_index_includes_extra_extension_files(self, tmp_path):
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
+
+    def test_shallow_index_includes_extra_extension_files(self):
         # Create files: one standard, one custom extension
-        (tmp_path / "main.py").write_text("print('hello')")
-        (tmp_path / "router.rsc").write_text("/ip address add")
+        with open(os.path.join(self.tmp_dir, "main.py"), "w") as f:
+            f.write("print('hello')")
+        with open(os.path.join(self.tmp_dir, "router.rsc"), "w") as f:
+            f.write("/ip address add")
 
         # Without extra_extensions: only .py is indexed
         mgr1 = ShallowIndexManager()
-        assert mgr1.set_project_path(str(tmp_path))
-        assert mgr1.build_index()
+        self.assertTrue(mgr1.set_project_path(self.tmp_dir))
+        self.assertTrue(mgr1.build_index())
         files1 = mgr1.get_file_list()
-        assert any(f.endswith(".py") for f in files1)
-        assert not any(f.endswith(".rsc") for f in files1)
+        self.assertTrue(any(f.endswith(".py") for f in files1))
+        self.assertFalse(any(f.endswith(".rsc") for f in files1))
 
         # With extra_extensions: .rsc is also indexed
         mgr2 = ShallowIndexManager()
-        assert mgr2.set_project_path(str(tmp_path), extra_extensions=[".rsc"])
-        assert mgr2.build_index()
+        self.assertTrue(mgr2.set_project_path(self.tmp_dir, extra_extensions=[".rsc"]))
+        self.assertTrue(mgr2.build_index())
         files2 = mgr2.get_file_list()
-        assert any(f.endswith(".py") for f in files2)
-        assert any(f.endswith(".rsc") for f in files2)
+        self.assertTrue(any(f.endswith(".py") for f in files2))
+        self.assertTrue(any(f.endswith(".rsc") for f in files2))
 
-    def test_shallow_find_files_with_custom_extension(self, tmp_path):
-        (tmp_path / "config.myext").write_text("key=value")
+    def test_shallow_find_files_with_custom_extension(self):
+        with open(os.path.join(self.tmp_dir, "config.myext"), "w") as f:
+            f.write("key=value")
         mgr = ShallowIndexManager()
-        assert mgr.set_project_path(str(tmp_path), extra_extensions=[".myext"])
-        assert mgr.build_index()
+        self.assertTrue(mgr.set_project_path(self.tmp_dir, extra_extensions=[".myext"]))
+        self.assertTrue(mgr.build_index())
         found = mgr.find_files("*.myext")
-        assert len(found) == 1
-        assert found[0].endswith("config.myext")
+        self.assertEqual(len(found), 1)
+        self.assertTrue(found[0].endswith("config.myext"))
 
 
 # --- SQLiteIndexManager ---
 
 
-class TestSQLiteIndexExtraExtensions:
+class TestSQLiteIndexExtraExtensions(unittest.TestCase):
     """Test that deep indexing picks up files with custom extensions."""
 
-    def test_deep_index_includes_extra_extension_files(self, tmp_path):
-        (tmp_path / "main.py").write_text("def foo(): pass")
-        (tmp_path / "router.rsc").write_text("/ip address add address=10.0.0.1")
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
+
+    def test_deep_index_includes_extra_extension_files(self):
+        with open(os.path.join(self.tmp_dir, "main.py"), "w") as f:
+            f.write("def foo(): pass")
+        with open(os.path.join(self.tmp_dir, "router.rsc"), "w") as f:
+            f.write("/ip address add address=10.0.0.1")
 
         # Without extra_extensions
         mgr1 = SQLiteIndexManager()
-        assert mgr1.set_project_path(str(tmp_path))
-        assert mgr1.build_index()
+        self.assertTrue(mgr1.set_project_path(self.tmp_dir))
+        self.assertTrue(mgr1.build_index())
         stats1 = mgr1.get_index_stats()
-        assert stats1["indexed_files"] == 1
+        self.assertEqual(stats1["indexed_files"], 1)
 
         # With extra_extensions
         mgr2 = SQLiteIndexManager()
-        assert mgr2.set_project_path(str(tmp_path), extra_extensions=[".rsc"])
-        assert mgr2.build_index()
+        self.assertTrue(mgr2.set_project_path(self.tmp_dir, extra_extensions=[".rsc"]))
+        self.assertTrue(mgr2.build_index())
         stats2 = mgr2.get_index_stats()
-        assert stats2["indexed_files"] == 2
+        self.assertEqual(stats2["indexed_files"], 2)
 
 
 # --- CLI argument parsing ---
 
 
-class TestCLIExtraExtensions:
+class TestCLIExtraExtensions(unittest.TestCase):
     """Test --extra-extensions CLI flag parsing."""
 
     def test_parse_extra_extensions_flag(self):
         from code_index_mcp.server import _parse_args
         args = _parse_args(["--extra-extensions", ".rsc,.conf,.rules"])
-        assert args.extra_extensions == ".rsc,.conf,.rules"
+        self.assertEqual(args.extra_extensions, ".rsc,.conf,.rules")
 
     def test_parse_extra_extensions_default_none(self):
         from code_index_mcp.server import _parse_args
         args = _parse_args([])
-        assert args.extra_extensions is None
+        self.assertIsNone(args.extra_extensions)
 
 
 # --- Clearing stored extensions ---
 
 
-class TestClearingStoredExtensions:
+class TestClearingStoredExtensions(unittest.TestCase):
     """Test that extra_extensions=[] clears previously persisted extensions."""
 
-    def test_empty_list_clears_stored_extensions(self, tmp_path):
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
+
+    def test_empty_list_clears_stored_extensions(self):
         """Passing extra_extensions=[] should clear previously stored extensions."""
-        settings = ProjectSettings(str(tmp_path))
+        settings = ProjectSettings(self.tmp_dir)
         settings.update_extra_extensions([".rsc", ".conf"])
-        assert len(settings.get_extra_extensions()) == 2
+        self.assertEqual(len(settings.get_extra_extensions()), 2)
 
         settings.update_extra_extensions([])
-        assert settings.get_extra_extensions() == []
+        self.assertEqual(settings.get_extra_extensions(), [])
 
-    def test_none_does_not_touch_stored_extensions(self, tmp_path):
+    def test_none_does_not_touch_stored_extensions(self):
         """extra_extensions=None (not provided) should leave stored config intact."""
-        settings = ProjectSettings(str(tmp_path))
+        settings = ProjectSettings(self.tmp_dir)
         settings.update_extra_extensions([".rsc"])
-        assert len(settings.get_extra_extensions()) == 1
+        self.assertEqual(len(settings.get_extra_extensions()), 1)
 
         # Simulate service-layer condition: None means "not provided"
         extra_extensions = None
@@ -218,94 +260,102 @@ class TestClearingStoredExtensions:
             settings.update_extra_extensions(extra_extensions)
 
         # Extensions should still be there
-        assert settings.get_extra_extensions() == [".rsc"]
+        self.assertEqual(settings.get_extra_extensions(), [".rsc"])
 
 
 # --- Watcher rebuild preserves extensions ---
 
 
-class TestWatcherRebuildPreservesExtensions:
+class TestWatcherRebuildPreservesExtensions(unittest.TestCase):
     """Test that watcher-triggered rebuilds preserve custom extension files."""
 
-    def test_rebuild_preserves_custom_extension_files(self, tmp_path):
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
+
+    def test_rebuild_preserves_custom_extension_files(self):
         """After a simulated watcher rebuild, custom-extension files must still be indexed."""
-        (tmp_path / "main.py").write_text("print('hello')")
-        (tmp_path / "router.rsc").write_text("/ip address add")
+        with open(os.path.join(self.tmp_dir, "main.py"), "w") as f:
+            f.write("print('hello')")
+        with open(os.path.join(self.tmp_dir, "router.rsc"), "w") as f:
+            f.write("/ip address add")
 
         extra_exts = [".rsc"]
 
         # Initial build with custom extensions
         mgr = ShallowIndexManager()
-        assert mgr.set_project_path(str(tmp_path), extra_extensions=extra_exts)
-        assert mgr.build_index()
+        self.assertTrue(mgr.set_project_path(self.tmp_dir, extra_extensions=extra_exts))
+        self.assertTrue(mgr.build_index())
         files = mgr.get_file_list()
-        assert any(f.endswith(".rsc") for f in files)
+        self.assertTrue(any(f.endswith(".rsc") for f in files))
 
         # Simulate buggy rebuild WITHOUT extra_extensions (demonstrates the bug)
-        assert mgr.set_project_path(str(tmp_path))
-        assert mgr.build_index()
+        self.assertTrue(mgr.set_project_path(self.tmp_dir))
+        self.assertTrue(mgr.build_index())
         files_after_bad_rebuild = mgr.get_file_list()
-        assert not any(f.endswith(".rsc") for f in files_after_bad_rebuild)
+        self.assertFalse(any(f.endswith(".rsc") for f in files_after_bad_rebuild))
 
         # Simulate correct rebuild WITH extra_extensions (the fix)
-        assert mgr.set_project_path(str(tmp_path), extra_extensions=extra_exts)
-        assert mgr.build_index()
+        self.assertTrue(mgr.set_project_path(self.tmp_dir, extra_extensions=extra_exts))
+        self.assertTrue(mgr.build_index())
         files_after_good_rebuild = mgr.get_file_list()
-        assert any(f.endswith(".rsc") for f in files_after_good_rebuild)
+        self.assertTrue(any(f.endswith(".rsc") for f in files_after_good_rebuild))
 
 
 # --- CLI bootstrap _CLI_CONFIG behavior ---
 
 
-class TestCLIBootstrapExtraExtensions:
+class TestCLIBootstrapExtraExtensions(unittest.TestCase):
     """Test that main() correctly updates _CLI_CONFIG for extra_extensions."""
 
     def test_empty_string_flag_sets_empty_list(self):
         """--extra-extensions '' should set _CLI_CONFIG.extra_extensions to [] (explicit clear)."""
         from code_index_mcp.server import _CLI_CONFIG, main
-        from unittest.mock import patch
 
         with patch("code_index_mcp.server.mcp.run"):
             main(["--extra-extensions", ""])
 
-        assert _CLI_CONFIG.extra_extensions == []
+        self.assertEqual(_CLI_CONFIG.extra_extensions, [])
 
     def test_omitted_flag_sets_none(self):
         """Omitting --extra-extensions should set _CLI_CONFIG.extra_extensions to None."""
         from code_index_mcp.server import _CLI_CONFIG, main
-        from unittest.mock import patch
 
         with patch("code_index_mcp.server.mcp.run"):
             main([])
 
-        assert _CLI_CONFIG.extra_extensions is None
+        self.assertIsNone(_CLI_CONFIG.extra_extensions)
 
     def test_no_stale_leak_between_calls(self):
         """Calling main() without the flag after a call with it must not leak stale values."""
         from code_index_mcp.server import _CLI_CONFIG, main
-        from unittest.mock import patch
 
         with patch("code_index_mcp.server.mcp.run"):
             main(["--extra-extensions", ".rsc,.conf"])
 
-        assert _CLI_CONFIG.extra_extensions == [".rsc", ".conf"]
+        self.assertEqual(_CLI_CONFIG.extra_extensions, [".rsc", ".conf"])
 
         with patch("code_index_mcp.server.mcp.run"):
             main([])
 
-        assert _CLI_CONFIG.extra_extensions is None
+        self.assertIsNone(_CLI_CONFIG.extra_extensions)
 
     def test_explicit_clear_after_set(self):
         """main(['--extra-extensions', '']) after main(['--extra-extensions', '.rsc']) should clear."""
         from code_index_mcp.server import _CLI_CONFIG, main
-        from unittest.mock import patch
 
         with patch("code_index_mcp.server.mcp.run"):
             main(["--extra-extensions", ".rsc"])
 
-        assert _CLI_CONFIG.extra_extensions == [".rsc"]
+        self.assertEqual(_CLI_CONFIG.extra_extensions, [".rsc"])
 
         with patch("code_index_mcp.server.mcp.run"):
             main(["--extra-extensions", ""])
 
-        assert _CLI_CONFIG.extra_extensions == []
+        self.assertEqual(_CLI_CONFIG.extra_extensions, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_custom_extensions.py
+++ b/tests/test_custom_extensions.py
@@ -189,3 +189,66 @@ class TestCLIExtraExtensions:
         from code_index_mcp.server import _parse_args
         args = _parse_args([])
         assert args.extra_extensions is None
+
+
+# --- Clearing stored extensions ---
+
+
+class TestClearingStoredExtensions:
+    """Test that extra_extensions=[] clears previously persisted extensions."""
+
+    def test_empty_list_clears_stored_extensions(self, tmp_path):
+        """Passing extra_extensions=[] should clear previously stored extensions."""
+        settings = ProjectSettings(str(tmp_path))
+        settings.update_extra_extensions([".rsc", ".conf"])
+        assert len(settings.get_extra_extensions()) == 2
+
+        settings.update_extra_extensions([])
+        assert settings.get_extra_extensions() == []
+
+    def test_none_does_not_touch_stored_extensions(self, tmp_path):
+        """extra_extensions=None (not provided) should leave stored config intact."""
+        settings = ProjectSettings(str(tmp_path))
+        settings.update_extra_extensions([".rsc"])
+        assert len(settings.get_extra_extensions()) == 1
+
+        # Simulate service-layer condition: None means "not provided"
+        extra_extensions = None
+        if extra_extensions is not None:
+            settings.update_extra_extensions(extra_extensions)
+
+        # Extensions should still be there
+        assert settings.get_extra_extensions() == [".rsc"]
+
+
+# --- Watcher rebuild preserves extensions ---
+
+
+class TestWatcherRebuildPreservesExtensions:
+    """Test that watcher-triggered rebuilds preserve custom extension files."""
+
+    def test_rebuild_preserves_custom_extension_files(self, tmp_path):
+        """After a simulated watcher rebuild, custom-extension files must still be indexed."""
+        (tmp_path / "main.py").write_text("print('hello')")
+        (tmp_path / "router.rsc").write_text("/ip address add")
+
+        extra_exts = [".rsc"]
+
+        # Initial build with custom extensions
+        mgr = ShallowIndexManager()
+        assert mgr.set_project_path(str(tmp_path), extra_extensions=extra_exts)
+        assert mgr.build_index()
+        files = mgr.get_file_list()
+        assert any(f.endswith(".rsc") for f in files)
+
+        # Simulate buggy rebuild WITHOUT extra_extensions (demonstrates the bug)
+        assert mgr.set_project_path(str(tmp_path))
+        assert mgr.build_index()
+        files_after_bad_rebuild = mgr.get_file_list()
+        assert not any(f.endswith(".rsc") for f in files_after_bad_rebuild)
+
+        # Simulate correct rebuild WITH extra_extensions (the fix)
+        assert mgr.set_project_path(str(tmp_path), extra_extensions=extra_exts)
+        assert mgr.build_index()
+        files_after_good_rebuild = mgr.get_file_list()
+        assert any(f.endswith(".rsc") for f in files_after_good_rebuild)

--- a/tests/test_custom_extensions.py
+++ b/tests/test_custom_extensions.py
@@ -1,0 +1,191 @@
+"""Tests for custom file extensions configuration (Issue #81).
+
+Verify that extra_extensions flows correctly through:
+- ProjectSettings persistence and retrieval
+- FileFilter extension matching
+- ShallowIndexManager file discovery
+- SQLiteIndexManager deep indexing
+- CLI argument parsing
+- Environment variable support
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from code_index_mcp.project_settings import ProjectSettings
+from code_index_mcp.utils.file_filter import FileFilter
+from code_index_mcp.indexing.shallow_index_manager import ShallowIndexManager
+from code_index_mcp.indexing.sqlite_index_manager import SQLiteIndexManager
+
+
+# --- ProjectSettings ---
+
+
+class TestProjectSettingsExtraExtensions:
+    """Test extra_extensions persistence in ProjectSettings."""
+
+    def test_update_and_get_extra_extensions(self, tmp_path):
+        settings = ProjectSettings(str(tmp_path))
+        settings.update_extra_extensions([".rsc", ".conf", "rules"])
+        result = settings.get_extra_extensions()
+        assert ".rsc" in result
+        assert ".conf" in result
+        assert ".rules" in result  # auto-prefixed with dot
+
+    def test_get_extra_extensions_empty_by_default(self, tmp_path):
+        settings = ProjectSettings(str(tmp_path))
+        assert settings.get_extra_extensions() == []
+
+    def test_extra_extensions_normalized_lowercase(self, tmp_path):
+        settings = ProjectSettings(str(tmp_path))
+        settings.update_extra_extensions([".RSC", ".Conf"])
+        result = settings.get_extra_extensions()
+        assert ".rsc" in result
+        assert ".conf" in result
+
+    def test_extra_extensions_deduplication(self, tmp_path):
+        settings = ProjectSettings(str(tmp_path))
+        settings.update_extra_extensions([".rsc", ".rsc", ".conf"])
+        result = settings.get_extra_extensions()
+        assert result.count(".rsc") == 1
+
+    def test_extra_extensions_from_env_variable(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("EXTRA_EXTENSIONS", ".rsc,.conf,.rules")
+        settings = ProjectSettings(str(tmp_path))
+        result = settings.get_extra_extensions()
+        assert ".rsc" in result
+        assert ".conf" in result
+        assert ".rules" in result
+
+    def test_extra_extensions_merged_config_and_env(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("EXTRA_EXTENSIONS", ".env_ext")
+        settings = ProjectSettings(str(tmp_path))
+        settings.update_extra_extensions([".config_ext"])
+        result = settings.get_extra_extensions()
+        assert ".config_ext" in result
+        assert ".env_ext" in result
+
+    def test_extra_extensions_env_without_dots(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("EXTRA_EXTENSIONS", "rsc,conf")
+        settings = ProjectSettings(str(tmp_path))
+        result = settings.get_extra_extensions()
+        assert ".rsc" in result
+        assert ".conf" in result
+
+
+# --- FileFilter ---
+
+
+class TestFileFilterExtraExtensions:
+    """Test FileFilter includes extra extensions."""
+
+    def test_extra_extension_accepted(self):
+        ff = FileFilter(extra_extensions=[".rsc"])
+        assert ".rsc" in ff.supported_extensions
+
+    def test_extra_extension_file_not_excluded(self, tmp_path):
+        ff = FileFilter(extra_extensions=[".rsc"])
+        test_file = tmp_path / "script.rsc"
+        test_file.write_text("# router script")
+        assert not ff.should_exclude_file(test_file)
+
+    def test_without_extra_extension_file_excluded(self, tmp_path):
+        ff = FileFilter()
+        test_file = tmp_path / "script.rsc"
+        test_file.write_text("# router script")
+        assert ff.should_exclude_file(test_file)
+
+    def test_extra_extension_normalizes_case(self):
+        ff = FileFilter(extra_extensions=[".RSC"])
+        assert ".rsc" in ff.supported_extensions
+
+    def test_extra_extension_adds_dot_prefix(self):
+        ff = FileFilter(extra_extensions=["rsc"])
+        assert ".rsc" in ff.supported_extensions
+
+    def test_should_process_path_with_extra_extension(self, tmp_path):
+        ff = FileFilter(extra_extensions=[".rsc"])
+        test_file = tmp_path / "script.rsc"
+        test_file.write_text("# content")
+        assert ff.should_process_path(test_file, tmp_path)
+
+
+# --- ShallowIndexManager ---
+
+
+class TestShallowIndexExtraExtensions:
+    """Test that shallow indexing picks up files with custom extensions."""
+
+    def test_shallow_index_includes_extra_extension_files(self, tmp_path):
+        # Create files: one standard, one custom extension
+        (tmp_path / "main.py").write_text("print('hello')")
+        (tmp_path / "router.rsc").write_text("/ip address add")
+
+        # Without extra_extensions: only .py is indexed
+        mgr1 = ShallowIndexManager()
+        assert mgr1.set_project_path(str(tmp_path))
+        assert mgr1.build_index()
+        files1 = mgr1.get_file_list()
+        assert any(f.endswith(".py") for f in files1)
+        assert not any(f.endswith(".rsc") for f in files1)
+
+        # With extra_extensions: .rsc is also indexed
+        mgr2 = ShallowIndexManager()
+        assert mgr2.set_project_path(str(tmp_path), extra_extensions=[".rsc"])
+        assert mgr2.build_index()
+        files2 = mgr2.get_file_list()
+        assert any(f.endswith(".py") for f in files2)
+        assert any(f.endswith(".rsc") for f in files2)
+
+    def test_shallow_find_files_with_custom_extension(self, tmp_path):
+        (tmp_path / "config.myext").write_text("key=value")
+        mgr = ShallowIndexManager()
+        assert mgr.set_project_path(str(tmp_path), extra_extensions=[".myext"])
+        assert mgr.build_index()
+        found = mgr.find_files("*.myext")
+        assert len(found) == 1
+        assert found[0].endswith("config.myext")
+
+
+# --- SQLiteIndexManager ---
+
+
+class TestSQLiteIndexExtraExtensions:
+    """Test that deep indexing picks up files with custom extensions."""
+
+    def test_deep_index_includes_extra_extension_files(self, tmp_path):
+        (tmp_path / "main.py").write_text("def foo(): pass")
+        (tmp_path / "router.rsc").write_text("/ip address add address=10.0.0.1")
+
+        # Without extra_extensions
+        mgr1 = SQLiteIndexManager()
+        assert mgr1.set_project_path(str(tmp_path))
+        assert mgr1.build_index()
+        stats1 = mgr1.get_index_stats()
+        assert stats1["indexed_files"] == 1
+
+        # With extra_extensions
+        mgr2 = SQLiteIndexManager()
+        assert mgr2.set_project_path(str(tmp_path), extra_extensions=[".rsc"])
+        assert mgr2.build_index()
+        stats2 = mgr2.get_index_stats()
+        assert stats2["indexed_files"] == 2
+
+
+# --- CLI argument parsing ---
+
+
+class TestCLIExtraExtensions:
+    """Test --extra-extensions CLI flag parsing."""
+
+    def test_parse_extra_extensions_flag(self):
+        from code_index_mcp.server import _parse_args
+        args = _parse_args(["--extra-extensions", ".rsc,.conf,.rules"])
+        assert args.extra_extensions == ".rsc,.conf,.rules"
+
+    def test_parse_extra_extensions_default_none(self):
+        from code_index_mcp.server import _parse_args
+        args = _parse_args([])
+        assert args.extra_extensions is None


### PR DESCRIPTION
## Summary

Closes #81

- Add `extra_extensions` parameter to `set_project_path` tool so users can pass additional file extensions (e.g., `[".rsc", ".conf", ".rules"]`) at project initialization time
- Add `EXTRA_EXTENSIONS` environment variable support (comma-separated, e.g., `EXTRA_EXTENSIONS=.rsc,.conf,.rules`)
- Add `--extra-extensions` CLI flag (e.g., `--extra-extensions .rsc,.conf,.rules`)
- Extensions are persisted in project config via `ProjectSettings`, merged with built-in `SUPPORTED_EXTENSIONS` through `FileFilter`, and used by both shallow and deep indexing pipelines
- Custom extension files use the existing fallback parsing strategy

## Changes

| File | Change |
|------|--------|
| `project_settings.py` | Added `update_extra_extensions()` and `get_extra_extensions()` methods |
| `utils/file_filter.py` | Added `extra_extensions` parameter to `FileFilter.__init__` |
| `server.py` | Added `extra_extensions` param to `set_project_path` tool, `--extra-extensions` CLI flag |
| `services/project_management_service.py` | Plumbed `extra_extensions` through initialization workflow |
| `services/index_management_service.py` | Plumbed `extra_extensions` through rebuild workflows |
| `indexing/json_index_builder.py` | Accepts `extra_extensions` and passes to `FileFilter` |
| `indexing/shallow_index_manager.py` | Accepts `extra_extensions` and passes to `JSONIndexBuilder` |
| `indexing/sqlite_index_builder.py` | Accepts `extra_extensions` and passes to parent |
| `indexing/sqlite_index_manager.py` | Accepts `extra_extensions` and passes to builder |

## Test plan

- [x] 18 new tests in `tests/test_custom_extensions.py` covering:
  - ProjectSettings persistence and retrieval of extra extensions
  - Normalization (lowercase, dot prefix, deduplication)
  - Environment variable parsing
  - Merged config + env variable sources
  - FileFilter extension acceptance/rejection
  - ShallowIndexManager file discovery with custom extensions
  - SQLiteIndexManager deep indexing with custom extensions
  - CLI argument parsing
- [x] All 110 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)