### PR TITLE
feat: fall back to cwd when no explicit project path is configured

### DIFF
--- a/src/code_index_mcp/server.py
+++ b/src/code_index_mcp/server.py
@@ -590,8 +590,11 @@ def main(argv: list[str] | None = None):
     args = _parse_args(argv)
 
     # Store CLI configuration for lifespan bootstrap.
-    # CLI --project-path takes precedence over PROJECT_PATH env var.
-    _CLI_CONFIG.project_path = args.project_path or os.environ.get("PROJECT_PATH") or None
+    # CLI --project-path takes precedence over PROJECT_PATH env var,
+    # which takes precedence over the current working directory.
+    _CLI_CONFIG.project_path = (
+        args.project_path or os.environ.get("PROJECT_PATH") or os.getcwd()
+    )
 
     # Read FILE_WATCHER_ENABLED from env (only when not already set via CLI).
     file_watcher_env = os.environ.get("FILE_WATCHER_ENABLED", "").strip().lower()

--- a/tests/test_env_config.py
+++ b/tests/test_env_config.py
@@ -41,13 +41,13 @@ class TestEnvVarProjectPath(unittest.TestCase):
         self.assertEqual(_CLI_CONFIG.project_path, "/tmp/cli_project")
 
     @patch("code_index_mcp.server.mcp.run")
-    def test_no_project_path(self, mock_run):
-        """No project path when neither CLI nor env var is set."""
+    def test_no_project_path_falls_back_to_cwd(self, mock_run):
+        """Falls back to cwd when neither CLI nor env var is set."""
         env = os.environ.copy()
         env.pop("PROJECT_PATH", None)
         with patch.dict(os.environ, env, clear=True):
             main([])
-        self.assertIsNone(_CLI_CONFIG.project_path)
+        self.assertEqual(_CLI_CONFIG.project_path, os.getcwd())
 
 
 class TestEnvVarFileWatcher(unittest.TestCase):


### PR DESCRIPTION
## Summary

When neither `--project-path` CLI argument nor `PROJECT_PATH` environment variable is set, the server now uses `os.getcwd()` as the default project path instead of starting uninitialized.

## Motivation

Many MCP hosting environments (e.g. OpenCode with mcp-proxy, or similar setups) launch the server as a child process that inherits the parent's working directory, which is already set to the project root. Currently, these environments must either:

1. Pass `--project-path` or `PROJECT_PATH` explicitly in their configuration
2. Have the agent call `set_project_path` at runtime before using any tools

Both require extra configuration that could be avoided since the CWD already points to the correct directory. This is especially relevant for **git worktree** workflows where the project path varies per worktree and can't be statically configured.

## Changes

- **`src/code_index_mcp/server.py`**: Added `os.getcwd()` as the final fallback in the project path resolution chain: `--project-path` > `PROJECT_PATH` env var > `os.getcwd()`
- **`tests/test_env_config.py`**: Updated `test_no_project_path` → `test_no_project_path_falls_back_to_cwd` to verify the new fallback behavior

## Priority order (unchanged for existing users)

1. `--project-path` CLI argument (highest)
2. `PROJECT_PATH` environment variable
3. `os.getcwd()` (new fallback)

Users who explicitly set a project path via CLI or env var see no behavior change. The only difference is for users who previously had no path configured — they now get automatic project detection instead of an uninitialized server.

## Tests

All 159 existing tests pass, including the updated test for the new fallback behavior.